### PR TITLE
WIP:  BTC rework dock move calculation

### DIFF
--- a/Klipper/README.md
+++ b/Klipper/README.md
@@ -24,3 +24,6 @@ Instructions are [here](https://github.com/Bikin-Creative/Lineux-Toolchanger/blo
 6. btc_klicky <- Required if using klicky probe
 7. btc_extras <- Sample macros to use in start/end print
 8. leds_x.cfg <- Required if using led effect
+
+# Instructions
+

--- a/Klipper/README.md
+++ b/Klipper/README.md
@@ -27,3 +27,29 @@ Instructions are [here](https://github.com/Bikin-Creative/Lineux-Toolchanger/blo
 
 # Instructions
 
+With 1 or more tools installed and docked. Several values must be idnetified.
+
+First, manually attach a tool to the carriage and home X/Y axis.
+then jog the carriage and find out the `variable_tool_approachlocation_y`. 
+This is a closes Y coordinate to the docks where the carriage can travel full length of X direction without hitting any docked tools.
+Note this coordinate down and set it in `btc_variables.cfg`.
+
+Then to carefuly and slowly manually jog the carraige to the dock of the current tool and make it dock. 
+it is advisable to go slow in this step to ensure the dock does not get broken.
+
+Once the tool is docked, note down the X,Y coordinates of the carriage and configure them in the tool_*.cfg file.
+
+```
+[gcode_macro _Variables_t0]
+variable_docked_x: 000 # Set to th Dock X location for this tool
+variable_docked_y: 000 # Set to the Dock Y location for this tool
+```
+
+Carefully jog the carriage in X direction to undock the tool, note the distance required for pins to fully leave the dock.
+it should be about 12-13mm for Lineux One toolheads.
+
+Set this value in `btc_variables.cfg`:
+
+```
+Variable_tool_lock_relative_x_move: 13
+```

--- a/Klipper/btc.cfg
+++ b/Klipper/btc.cfg
@@ -1,6 +1,8 @@
 [include ./btc_variables.cfg]  # Required
 [include ./tool_0.cfg]         # Required
-[include ./tool_1.cfg]         # Required if second tool available, and so on
+#[include ./tool_1.cfg]         # Required if second tool available, and so on
+
+#[include ./btc_klicky.cfg]    # if you're using klicky probe
 [include ./bashed_macros.cfg]  # Comment out once done at least 100 iterations of toolchange
 #[include ./btc_nudge.cfg]     # Uncomment when doing tool alignment using zruncho nudge tool
 #[include ./dockslide.cfg]     # Uncomment if using Dockslide
@@ -152,8 +154,8 @@ gcode:
   {% set tool_current_asperbtc = toolvar.tool_current_asperbtc %}
   {% set use_dockslide = toolvar.use_dockslide %}
   {% set performed_dropoff = False %}
-  {% if tool_current_asperbtc != toolnumber %}
-    {% if tool_z_hop != 0 %}
+  {% if tool_current_asperbtc != toolnumber %} #we need to switch the tool
+    {% if tool_z_hop != 0 %} # move Z safe distance if needed
       SAVE_GCODE_STATE NAME=TOOL_ZHOP_STATE
       G91
       G0 Z{tool_z_hop}
@@ -175,43 +177,58 @@ gcode:
     {% set tool_travel_feedrate = toolvar.btc_travel_speed * 60 %}
     {% set tool_change_feedrate = toolvar.btc_toolchange_speed * 60 %}
     {% set tool_approachlocation_y = toolvar.tool_approachlocation_y %}
-    {% set tool_pickupmove_y = toolvar.tool_pickupmove_y %}
-    {% set tool_pickupmove_x = toolvar.tool_pickupmove_x %}
-    {% set tool_pickuplocation_x = printer["gcode_macro _Variables_t" + toolnumber|string].pickuplocation_x %}
+
+    {% set tool_docked_x = printer["gcode_macro _Variables_t" + toolnumber|string].docked_x %}
+    {% set tool_docked_y = printer["gcode_macro _Variables_t" + toolnumber|string].docked_y %}
+
+    {% set tool_lock_move = toolvar.lock_relative_x_move %} # this will be inverted for locking
+
     {% set tool_zoffset = printer["gcode_macro _Variables_t" + toolnumber|string].zoffset %}
     SET_GCODE_OFFSET MOVE=1 Z={tool_zoffset} #apply the z offset before loading the new one to ensure no nozzle crash
     SAVE_GCODE_STATE NAME=TOOL_PICKUP_STATE
-    { action_respond_info("BTC: Move to approach location X%d Y%d" % (tool_pickuplocation_x, tool_approachlocation_y)) }
-    G0 X{tool_pickuplocation_x} Y{tool_approachlocation_y} F{tool_travel_feedrate}
+
+    G90
+    
+    { action_respond_info("BTC: Move to approach location X%d Y%d" % (tool_docked_x, tool_approachlocation_y)) }
+    G0 X{tool_docked_x} Y{tool_approachlocation_y} F{tool_travel_feedrate} #move to approach location
+
     {% if use_dockslide %}
       {% if not performed_dropoff %}
         { action_respond_info("BTC: Dockslide Deploy") }
         Dockslide_Deploy
       {% endif %}
     {% endif %}
-    { action_respond_info("BTC: Move to position 2 Y%d" % (tool_approachlocation_y + tool_pickupmove_y)) }
-    G0 Y{tool_approachlocation_y + tool_pickupmove_y} F{tool_change_feedrate}
-    { action_respond_info("BTC: Move to position 3 X%d" % (tool_pickuplocation_x + tool_pickupmove_x)) }
-    G0 X{tool_pickuplocation_x + tool_pickupmove_x}
+
+    { action_respond_info("BTC: Aproaching tool in Y%d" % (tool_docked_y)) }
+    G0 Y{tool_docked_y} F{tool_change_feedrate}
+    
+    { action_respond_info("BTC: Picking up the tool. X%d" % (tool_docked_x)) }
+    G0 X{tool_docked_x+tool_lock_move} # pick up the tool
+    #tool is now locked on the carriage
+
     M400 # Wait for moves to complete before leaving dock
+   
     { action_respond_info("BTC: Wipe nozzle") }
-    {% if tool_pickupmove_y > 0 %} # Dock at rear
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y - 15} F{tool_travel_feedrate}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y - 2}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y - 15}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y - 2}
+    {% if tool_approachlocation_y < tool_docked_y %} # Dock at rear
+      G0 Y{tool_docked_y - 15} F{tool_travel_feedrate}
+      G0 Y{tool_docked_y - 2}
+      G0 Y{tool_docked_y - 15}
+      G0 Y{tool_docked_y - 2}
     {% else %} # Dock at front
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y + 15} F{tool_travel_feedrate}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y + 2}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y + 15}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y + 2}
+      G0 Y{tool_docked_y + 15} F{tool_travel_feedrate} # 70-15=55
+      G0 Y{tool_docked_y + 2} # 70-2 = 68
+      G0 Y{tool_docked_y + 15}
+      G0 Y{tool_docked_y + 2}
     {% endif %}
-    { action_respond_info("BTC: Move to position 4 Y%d" % (tool_approachlocation_y)) }
+
+    { action_respond_info("BTC: Move back to safe approach location Y%d" % (tool_approachlocation_y)) }
     G0 Y{tool_approachlocation_y} F{tool_travel_feedrate}
+
     {% if use_dockslide %}
       { action_respond_info("BTC: Dockslide Park") }
       Dockslide_Park
     {% endif %}
+
     RESTORE_GCODE_STATE NAME=TOOL_PICKUP_STATE
     _CHECK_CARRIAGE_SECOND TOOLNUMBER={toolnumber} FROMPICKUP=1
   {% endif %}
@@ -244,30 +261,38 @@ gcode:
     { action_respond_info("BTC: Dropoff tool %d, active tool is %s - Proceeding dropoff" % (toolnumber, tool_current_asperbtc)) }
     {% set tool_travel_feedrate = toolvar.btc_travel_speed * 60 %}
     {% set tool_change_feedrate = toolvar.btc_toolchange_speed * 60 %}
-    {% set tool_dropofflocation_x = printer["gcode_macro _Variables_t" + toolnumber|string].dropofflocation_x %}
     {% set tool_approachlocation_y = toolvar.tool_approachlocation_y %}
-    {% set tool_dockmove_y = toolvar.tool_dropoffmove_y %}
-    {% set tool_dockmove_x = toolvar.tool_dropoffmove_x %}
+    {% set tool_docked_x = printer["gcode_macro _Variables_t" + toolnumber|string].docked_x %}
+    {% set tool_docked_y = printer["gcode_macro _Variables_t" + toolnumber|string].docked_y %}
+
+    {% set tool_lock_move = toolvar.lock_relative_x_move %} # will be inverted to dock the tool
     SET_GCODE_OFFSET MOVE=1 X=0 Y=0		#set XY offset to zero so that the docking is not misaligned
     SAVE_GCODE_STATE NAME=TOOL_DROPOFF_STATE
-    { action_respond_info("BTC: Move to approach location X%d Y%d" % (tool_dropofflocation_x, tool_approachlocation_y)) }
-    G0 X{tool_dropofflocation_x} Y{tool_approachlocation_y} F{tool_travel_feedrate}
+    G90 #ensure absolute positioning
+    { action_respond_info("BTC: Move to approach location X%d Y%d" % (tool_docked_x, tool_approachlocation_y)) }
+    G0 X{tool_docked_x+tool_lock_move} Y{tool_approachlocation_y} F{tool_travel_feedrate} # subtract unlock move to get unlocked location
+    
+   
     {% if use_dockslide %}
       { action_respond_info("BTC: Dockslide Deploy") }
       Dockslide_Deploy
     {% endif %}
-    { action_respond_info("BTC: Move to position 2 Y%d" % (tool_approachlocation_y + tool_dockmove_y)) }
-    G0 Y{tool_approachlocation_y + tool_dockmove_y} F{tool_change_feedrate}
-    { action_respond_info("BTC: Move to position 3 X%d" % (tool_dropofflocation_x + tool_dockmove_x)) }
-    G0 X{tool_dropofflocation_x + tool_dockmove_x}
-    { action_respond_info("BTC: Move to position 4 Y%d" % (tool_approachlocation_y)) }
+
+    { action_respond_info("BTC: Approaching Dock in Y%d" % (tool_docked_y)) }
+    G0 Y{tool_docked_y} F{tool_change_feedrate} # approach the tool in Y
+
+    { action_respond_info("BTC: Docking tool X%d" % (tool_docked_x)) }
+    G0 X{tool_docked_x} # dock tool
+    { action_respond_info("BTC: Returning to safe distance Y%d" % (tool_approachlocation_y)) }
     G0 Y{tool_approachlocation_y} F{tool_travel_feedrate}
+
     {% if use_dockslide %}
       {% if frompickup != 1 %}
         { action_respond_info("BTC: Dockslide Park") }
         Dockslide_Park
       {% endif %}
     {% endif %}
+
     RESTORE_GCODE_STATE NAME=TOOL_DROPOFF_STATE
     M400
     _check_dock_third TOOLNUMBER={toolnumber} FROMDROPOFF=1
@@ -277,37 +302,37 @@ gcode:
 ### end Tool dropoff routine ###
 
 ### start Fan and temperature override ###
-[gcode_macro M106]
-gcode:
-  {% if params.S is defined %}
-    {% set converted_speeds = params.S|int / 255 %}
-    {% if converted_speeds > 1 %}
-      {% set converted_speed = 1 %}
-    {% else %}
-      {% set converted_speed = converted_speeds %}
-    {% endif %}
-  {% else %}
-    {% set converted_speed = 1.0 %}
-  {% endif %}
-  {% if params.P is defined %}
-    SET_FAN_SPEED FAN=partfan{params.P} SPEED={converted_speed|float}
-  {% else %}
-    {% set curtool = printer["gcode_macro _btc_Variables"].tool_current_asperbtc %}
-    M107
-    SET_FAN_SPEED FAN=partfan{curtool} SPEED={converted_speed|float}
-    SET_GCODE_VARIABLE MACRO=_btc_Variables VARIABLE=last_fan_speed VALUE={converted_speed}
-  {% endif %}
+# [gcode_macro M106]
+# gcode:
+#   {% if params.S is defined %}
+#     {% set converted_speeds = params.S|int / 255 %}
+#     {% if converted_speeds > 1 %}
+#       {% set converted_speed = 1 %}
+#     {% else %}
+#       {% set converted_speed = converted_speeds %}
+#     {% endif %}
+#   {% else %}
+#     {% set converted_speed = 1.0 %}
+#   {% endif %}
+#   {% if params.P is defined %}
+#     SET_FAN_SPEED FAN=partfan{params.P} SPEED={converted_speed|float}
+#   {% else %}
+#     {% set curtool = printer["gcode_macro _btc_Variables"].tool_current_asperbtc %}
+#     M107
+#     SET_FAN_SPEED FAN=partfan{curtool} SPEED={converted_speed|float}
+#     SET_GCODE_VARIABLE MACRO=_btc_Variables VARIABLE=last_fan_speed VALUE={converted_speed}
+#   {% endif %}
 
-[gcode_macro M107]
-gcode:
-  {% if params.P is defined %}
-    SET_FAN_SPEED FAN=partfan{params.P} SPEED=0.0
-  {% else %}
-    {% set numoftool = printer["gcode_macro _btc_Variables"].numoftool %}
-    {% for toolnumber in numoftool %}
-      SET_FAN_SPEED FAN=partfan{toolnumber} SPEED=0.0
-    {% endfor %}
-  {% endif %}
+# [gcode_macro M107]
+# gcode:
+#   {% if params.P is defined %}
+#     SET_FAN_SPEED FAN=partfan{params.P} SPEED=0.0
+#   {% else %}
+#     {% set numoftool = printer["gcode_macro _btc_Variables"].numoftool %}
+#     {% for toolnumber in numoftool %}
+#       SET_FAN_SPEED FAN=partfan{toolnumber} SPEED=0.0
+#     {% endfor %}
+#   {% endif %}
 
 ########################################################################################
 # This override was created by Ellis @ https://ellis3dp.com as part of his Useful Macros

--- a/Klipper/btc.cfg
+++ b/Klipper/btc.cfg
@@ -302,37 +302,37 @@ gcode:
 ### end Tool dropoff routine ###
 
 ### start Fan and temperature override ###
-# [gcode_macro M106]
-# gcode:
-#   {% if params.S is defined %}
-#     {% set converted_speeds = params.S|int / 255 %}
-#     {% if converted_speeds > 1 %}
-#       {% set converted_speed = 1 %}
-#     {% else %}
-#       {% set converted_speed = converted_speeds %}
-#     {% endif %}
-#   {% else %}
-#     {% set converted_speed = 1.0 %}
-#   {% endif %}
-#   {% if params.P is defined %}
-#     SET_FAN_SPEED FAN=partfan{params.P} SPEED={converted_speed|float}
-#   {% else %}
-#     {% set curtool = printer["gcode_macro _btc_Variables"].tool_current_asperbtc %}
-#     M107
-#     SET_FAN_SPEED FAN=partfan{curtool} SPEED={converted_speed|float}
-#     SET_GCODE_VARIABLE MACRO=_btc_Variables VARIABLE=last_fan_speed VALUE={converted_speed}
-#   {% endif %}
+[gcode_macro M106]
+gcode:
+  {% if params.S is defined %}
+    {% set converted_speeds = params.S|int / 255 %}
+    {% if converted_speeds > 1 %}
+      {% set converted_speed = 1 %}
+    {% else %}
+      {% set converted_speed = converted_speeds %}
+    {% endif %}
+  {% else %}
+    {% set converted_speed = 1.0 %}
+  {% endif %}
+  {% if params.P is defined %}
+    SET_FAN_SPEED FAN=partfan{params.P} SPEED={converted_speed|float}
+  {% else %}
+    {% set curtool = printer["gcode_macro _btc_Variables"].tool_current_asperbtc %}
+    M107
+    SET_FAN_SPEED FAN=partfan{curtool} SPEED={converted_speed|float}
+    SET_GCODE_VARIABLE MACRO=_btc_Variables VARIABLE=last_fan_speed VALUE={converted_speed}
+  {% endif %}
 
-# [gcode_macro M107]
-# gcode:
-#   {% if params.P is defined %}
-#     SET_FAN_SPEED FAN=partfan{params.P} SPEED=0.0
-#   {% else %}
-#     {% set numoftool = printer["gcode_macro _btc_Variables"].numoftool %}
-#     {% for toolnumber in numoftool %}
-#       SET_FAN_SPEED FAN=partfan{toolnumber} SPEED=0.0
-#     {% endfor %}
-#   {% endif %}
+[gcode_macro M107]
+gcode:
+  {% if params.P is defined %}
+    SET_FAN_SPEED FAN=partfan{params.P} SPEED=0.0
+  {% else %}
+    {% set numoftool = printer["gcode_macro _btc_Variables"].numoftool %}
+    {% for toolnumber in numoftool %}
+      SET_FAN_SPEED FAN=partfan{toolnumber} SPEED=0.0
+    {% endfor %}
+  {% endif %}
 
 ########################################################################################
 # This override was created by Ellis @ https://ellis3dp.com as part of his Useful Macros

--- a/Klipper/btc_variables.cfg
+++ b/Klipper/btc_variables.cfg
@@ -8,13 +8,14 @@ variable_btc_z_hop:        0    # set this to 0 to disable z hop
 variable_btc_temp_allow:        1.0    # Temperature allowance. This is range of set temperature. Use higher value if your pid is bad
 variable_btc_inc_leds: True       # Using neopixel
 
-variable_tool_approachlocation_y:      220    # Y absolute approach position
+variable_tool_approachlocation_y:      0    # Y absolute approach position
 ################################################
 # These below moves are relative!!
-Variable_tool_pickupmove_y:             79    # Enter moves in mm
+Variable_tool_pickupmove_y:             -70    # Enter moves in mm
 Variable_tool_pickupmove_x:          -10      #
-Variable_tool_dropoffmove_y:             79   #
+Variable_tool_dropoffmove_y:             -70   #
 Variable_tool_dropoffmove_x:          10      #
+Variable_tool_lock_relative_x_move: 13 # relative X move to pickup the tool from the dock
 ##################################################
 # Options ends here!!!
 

--- a/Klipper/btc_variables.cfg
+++ b/Klipper/btc_variables.cfg
@@ -11,10 +11,6 @@ variable_btc_inc_leds: True       # Using neopixel
 variable_tool_approachlocation_y:      0    # Y absolute approach position
 ################################################
 # These below moves are relative!!
-Variable_tool_pickupmove_y:             -70    # Enter moves in mm
-Variable_tool_pickupmove_x:          -10      #
-Variable_tool_dropoffmove_y:             -70   #
-Variable_tool_dropoffmove_x:          10      #
 Variable_tool_lock_relative_x_move: 13 # relative X move to pickup the tool from the dock
 ##################################################
 # Options ends here!!!

--- a/Klipper/tool_0.cfg
+++ b/Klipper/tool_0.cfg
@@ -11,6 +11,8 @@
 [gcode_macro _Variables_t0]
 variable_pickuplocation_x:      324   # X Dock position for pickup move
 variable_dropofflocation_x:      312    # X Dock position for dropoff move
+variable_docked_x: 13
+variable_docked_y: -70
 
 variable_xoffset: 0              # For tool 0, offsets are all 0
 variable_yoffset: 0              #

--- a/Klipper/tool_0.cfg
+++ b/Klipper/tool_0.cfg
@@ -9,13 +9,11 @@
 ####################
 # Tool0 Variables
 [gcode_macro _Variables_t0]
-variable_pickuplocation_x:      324   # X Dock position for pickup move
-variable_dropofflocation_x:      312    # X Dock position for dropoff move
-variable_docked_x: 13
-variable_docked_y: -70
+variable_docked_x: 324 # Set to th Dock X location for this tool
+variable_docked_y: -70 # Set to the Dock Y location for this tool
 
-variable_xoffset: 0              # For tool 0, offsets are all 0
-variable_yoffset: 0              #
+variable_xoffset: 0              # Nozzle calibration offsets
+variable_yoffset: 0              # For tool 0, offsets are all 0, other tools are offset relative to tool 0
 variable_zoffset: 0              #
 variable_shaperfreq_x: 54.2      # Tool 0 input shaper
 variable_shaperfreq_y: 55.2      #


### PR DESCRIPTION
WORK_IN_PROGRESS. DO NOT MERGE

@Bikin-Creative  a proposal to change how tool docking is configured:

dock location is set in tool_*.cfg files via `variable_docked_x` and variable_docked_y`. This is the absolute location of the tool when it is docked.

Then, use `lock_relative_x_move` global (set in btc_variables) to calculate approach, lock and unlock positions.

the new proposed config (dock related parts) for tools would look like this:
`btc_variables.cfg`
```
...
Variable_tool_approachlocation_y:      100
Variable_tool_lock_relative_x_move: 13  # relative X move to pickup the tool from the dock
...
```
`tool_0.cfg`
```
...
variable_docked_x: 13
variable_docked_y: -70
...
```
`tool_1.cfg`
```
...
variable_docked_x: 89
variable_docked_y: -70
...
```

Curious to hear your thoughts.