### PR TITLE
Create endstops.cfg

### DIFF
--- a/Klipper/endstops.cfg
+++ b/Klipper/endstops.cfg
@@ -1,0 +1,48 @@
+##############################################
+#          Frame Mounted Endstops            #
+##############################################
+# If you mount your X endstop to the frame, instead of the gantry, close to your Y endstop
+# this will home the Y axis before homing your X axis
+# Reworked set_postion into Y and X homing as conditional so the printer won't set to 0 when homing
+# when calibrating bed_mesh.
+# Added T0 command to Z homing to ensure the toolhead with the bed probe is selected.
+
+[homing_override]
+axes: yxz
+gcode:
+  {% set home_all = 'X' not in params and 'Y' not in params and 'Z' not in params %}
+
+  {% if home_all or 'Y' in params %}  
+    {% if not 'z' in printer.toolhead.homed_axes %} 
+    SET_KINEMATIC_POSITION Z=0   ## sets Z=0 if it has not been homed
+    {% endif %}
+    
+    G1 Z10 F1200   ## raise Z for clearance
+    G28 Y   
+  {% endif %}
+  
+  {% if home_all or 'X' in params %}
+    {% if not 'z' in printer.toolhead.homed_axes %}
+    SET_KINEMATIC_POSITION Z=0  ## sets Z=0 if it has not been homed
+    {% endif %}
+    
+    G1 Z10 F1200   ## raise Z for clearance
+    {% if not printer.toolhead.position.y == 0 %} ## check if Y is at 0 to insure the toolhead hits the x endstop
+        G28 Y   
+    {% endif %}    
+    G28 X    
+  {% endif %}
+
+  {% if home_all or 'Z' in params %}
+      {% if not 'xy' in printer.toolhead.homed_axes %}   ## checks it X and Y are homed
+         G1 Z10 F1200   ## raise Z for clearance
+         G28 Y 
+         G28 X
+      {% endif %} 
+    G1 Z10 F1200   ## raise Z for clearance
+    G90
+    G1 X200 Y185 F12000 
+#   T0  ## uncomment to enable toolhead change for homing, change if your probe is on a different toolhead
+    G28 Z   ## Home Z
+    G1 Z10 F1200
+  {% endif %}

--- a/Klipper/endstops.cfg
+++ b/Klipper/endstops.cfg
@@ -35,6 +35,7 @@ gcode:
 
   {% if home_all or 'Z' in params %}
       {% if not 'xy' in printer.toolhead.homed_axes %}   ## checks it X and Y are homed
+      SET_KINEMATIC_POSITION Z=0   ## sets Z=0 if it has not been homed
          G1 Z10 F1200   ## raise Z for clearance
          G28 Y 
          G28 X

--- a/Klipper/sample_homing_override.cfg
+++ b/Klipper/sample_homing_override.cfg
@@ -6,6 +6,9 @@
 # Reworked set_postion into Y and X homing as conditional so the printer won't set to 0 when homing
 # when calibrating bed_mesh.
 # Added T0 command to Z homing to ensure the toolhead with the bed probe is selected.
+#
+# Edit 3/4/2025: yantz74 <wnroheryanto@hotmail.com>
+# File is not designed to be included as is. Copy paste the example below into your printer.cfg and edit xyz positions accordingly, based on your own printer
 
 [homing_override]
 axes: yxz


### PR DESCRIPTION
Created to ensure Y axis homes before X axis when the x_endstop is mount to the frame and not the gantry or toolhead.
Revised to eliminate errors occurring when calibrating bed_mesh.