### PR TITLE
btc_nudge: Add configurable movement delay for preventing TTC errors

### DIFF
--- a/Klipper/btc_nudge.cfg
+++ b/Klipper/btc_nudge.cfg
@@ -11,6 +11,7 @@ release_gcode:
 [gcode_macro _nudge_variables]
 variable_nudge_resolution: 0.05      # Resolution should be between 0.01 - 0.1
 variable_nudge_travel_speed: 100
+variable_nudge_move_delay: -1        # If you're getting TTC errors during probing try increasing this value
 ################################################################################
 
 #############################################################################
@@ -99,6 +100,9 @@ gcode:
   {% endif %}
   {% for moves in range(1000) %}
     _do_nudge_move FINDING={finding}
+    {% if printer["gcode_macro _nudge_variables"].nudge_move_delay > -1 %}
+      G4 P{printer["gcode_macro _nudge_variables"].nudge_move_delay}
+    {% endif %}
   {% endfor %}
   {% if finding == "z" %}
     {% set move_direction = "Z3" %}


### PR DESCRIPTION
This adds a conditional movement delay to the probe moves in btc_nudge.
If set to `-1`, this won't change the previous behaviour.
If set to a value >= 0 this will introduce a small delay after each move, allowing the Klipper timings to be more lax and thus preventing the TTC errors.