### PR TITLE
Adding support for additional SET_GCODE_OFFSET Z_ADJUST values

### DIFF
--- a/Klipper/btc.cfg
+++ b/Klipper/btc.cfg
@@ -183,7 +183,10 @@ gcode:
     {% set tool_pickupmove_x = toolvar.tool_pickupmove_x %}
     {% set tool_pickuplocation_x = printer["gcode_macro _Variables_t" + toolnumber|string].pickuplocation_x %}
     {% set tool_zoffset = printer["gcode_macro _Variables_t" + toolnumber|string].zoffset %}
+    {% set z_adjust = toolvar.gcode_offset_z_adjust %}
     SET_GCODE_OFFSET MOVE=1 Z={tool_zoffset} #apply the z offset before loading the new one to ensure no nozzle crash
+    SET_GCODE_OFFSET MOVE=1 Z_ADJUST={z_adjust}
+    { action_respond_info("BTC: Z offset now %f (adjusted by %f)" % (tool_zoffset, z_adjust)) }
     SAVE_GCODE_STATE NAME=TOOL_PICKUP_STATE
     { action_respond_info("BTC: Move to approach location X%d Y%d" % (tool_pickuplocation_x, tool_approachlocation_y)) }
     G0 X{tool_pickuplocation_x} Y{tool_approachlocation_y} F{tool_travel_feedrate}

--- a/Klipper/btc_extras.cfg
+++ b/Klipper/btc_extras.cfg
@@ -176,4 +176,5 @@ gcode:
   {% set z_offset = params.Z|default(0.0)|float %}
   RESPOND MSG="Forwarding Z offset adjustment of {z_offset} to Lineux"
   SET_GCODE_VARIABLE MACRO=_btc_Variables VARIABLE=gcode_offset_z_adjust VALUE={z_offset}
+  SET_GCODE_OFFSET Z_ADJUST={z_offset}
 ########################################################################################

--- a/Klipper/btc_extras.cfg
+++ b/Klipper/btc_extras.cfg
@@ -168,3 +168,12 @@ rename_existing: _Z_TILT_ADJUST
 gcode:
   T0
   _Z_TILT_ADJUST {% for p in params %}{'%s=%s ' % (p, params[p])}{% endfor %}
+########################################################################################
+
+########################################################################################
+[gcode_macro Z_CALIBRATION_SET_OFFSET_MACRO]
+gcode:
+  {% set z_offset = params.Z|default(0.0)|float %}
+  RESPOND MSG="Forwarding Z offset adjustment of {z_offset} to Lineux"
+  SET_GCODE_VARIABLE MACRO=_btc_Variables VARIABLE=gcode_offset_z_adjust VALUE={z_offset}
+########################################################################################

--- a/Klipper/btc_variables.cfg
+++ b/Klipper/btc_variables.cfg
@@ -26,6 +26,7 @@ Variable_use_dockslide: False
 Variable_last_fan_speed: 0
 Variable_from_pickup:	False
 Variable_tools_used_inprint:	[]
+variable_gcode_offset_z_adjust: 0.0
 gcode:
 ###################################################
 


### PR DESCRIPTION
This PR adds support for setting an addition Z_ADJUST value when changing tools.

This can be for example used for this fork of klipper_z_calibration: https://github.com/irrenhaus/klipper_z_calibration which is pending for merge @ https://github.com/protoloft/klipper_z_calibration/pull/167.

An example macro that can be used for `klipper_z_calibration` is provided in Klipper/btc_extras.cfg as `Z_CALIBRATION_SET_OFFSET_MACRO`.