### PR TITLE
Add overwritable nozzle wiping

### DIFF
--- a/Klipper/btc.cfg
+++ b/Klipper/btc.cfg
@@ -200,15 +200,9 @@ gcode:
     M400 # Wait for moves to complete before leaving dock
     { action_respond_info("BTC: Wipe nozzle") }
     {% if tool_pickupmove_y > 0 %} # Dock at rear
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y - 15} F{tool_wipe_feedrate}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y - 2}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y - 15}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y - 2}
+      WIPE_NOZZLE DIRECTION=1 FEEDRATE={tool_wipe_feedrate} X={tool_pickuplocation_x + tool_pickupmove_x} Y={tool_approachlocation_y + tool_pickupmove_y}
     {% else %} # Dock at front
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y + 15} F{tool_wipe_feedrate}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y + 2}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y + 15}
-      G0 Y{tool_approachlocation_y + tool_pickupmove_y + 2}
+      WIPE_NOZZLE DIRECTION=-1 FEEDRATE={tool_wipe_feedrate} X={tool_pickuplocation_x + tool_pickupmove_x} Y={tool_approachlocation_y + tool_pickupmove_y}
     {% endif %}
     { action_respond_info("BTC: Move to position 4 Y%d" % (tool_approachlocation_y)) }
     G0 Y{tool_approachlocation_y} F{tool_travel_feedrate}
@@ -342,6 +336,28 @@ gcode:
     {% endif %}
 ########################################################################################
 ### end Fan and temperature override ###
+
+### default nozzle wiping ######################################
+[gcode_macro WIPE_NOZZLE]
+gcode:
+  {% set direction = params.DIRECTION|default(1)|int %}
+  {% set feed = params.FEEDRATE|default(600)|int %}
+  {% set pos_x = params.X|default(0)|float %}
+  {% set pos_y = params.Y|default(0)|float %}
+
+  {% if direction > 0 %} # Dock at rear
+    G0 Y{pos_y - 15} F{feed}
+    G0 Y{pos_y - 2}
+    G0 Y{pos_y - 15}
+    G0 Y{pos_y - 2}
+  {% else %} # Dock at front
+    G0 Y{pos_y + 15} F{feed}
+    G0 Y{pos_y + 2}
+    G0 Y{pos_y + 15}
+    G0 Y{pos_y + 2}
+  {% endif %}
+### end default nozzle wiping ##################################
+  
 
 ### start Led effect ###########################################
 [gcode_macro _btc_stop_led_effect]


### PR DESCRIPTION
This PR extracts the nozzle wiping motions to a separate macro.
The reasoning behind this is to allow for custom nozzle wiping motions for non-standard nozzle-wiping hardware.

In my case I switched to using Bambu A1 nozzle wiping pads and would like to have a more elaborate wiping motion, also wiping the nozzle sideways.

This change allows for overwriting the nozzle wiping movement without changing the default behaviour.