### PR TITLE
Feature/save variables support

### DIFF
--- a/Klipper/btc.cfg
+++ b/Klipper/btc.cfg
@@ -5,6 +5,7 @@
 #[include ./btc_nudge.cfg]     # Uncomment when doing tool alignment using zruncho nudge tool
 #[include ./dockslide.cfg]     # Uncomment if using Dockslide
 #[include ./btc_spoolman.cfg]     # Uncomment for Spoolman integration
+#[include ./btc_save_variables.cfg] # Uncomment for dynamic toolhead variables support
 [input_shaper]                 # Required for input shaper, do not delete
 
 [gcode_macro _UPDATE_FRONTEND]
@@ -46,6 +47,9 @@ gcode:
       { action_respond_info("BTC: Tool %d is defined" % (tools)) }
     {% endif %}
   {% endfor %}
+  {% if printer["gcode_macro _btc_Variables"].use_save_variables is defined and printer["gcode_macro _btc_Variables"].use_save_variables %}
+    Lineux_Load_Config
+  {% endif %}
   Check_Carriage
   _start_check_second
   {% if printer["gcode_macro Dockslide_Home"] is defined %}

--- a/Klipper/btc_nudge.cfg
+++ b/Klipper/btc_nudge.cfg
@@ -48,6 +48,12 @@ gcode:
     T{tool}
     _NUDGE_MOVE_OVER_PROBE
     M109 T{tool} S150
+
+    {% if printer["gcode_macro _btc_Variables"].use_save_variables %}
+      { action_respond_info("BTC_Nudge: Ensuring 0 offset on T" ~ tool ~ " for measurement") }
+      _set_toolhead_offset_variables TOOL={tool} XOFFSET=0 YOFFSET=0 ZOFFSET=0
+    {% endif %}
+
     {% if tool == 0 %}
       _TOOL_LOCATE_SENSOR
     {% else %}
@@ -213,10 +219,28 @@ gcode:
       { action_respond_info("BTC_Nudge: Y: %.2f" % (caly)) }
       { action_respond_info("BTC_Nudge: ------------") }
       SET_GCODE_VARIABLE MACRO=_nudge_variables VARIABLE=nudge_cal_y2 VALUE=-128
+      {% set xoffset = (calx - refx) %}
+      {% set yoffset = (caly - refy) %}
+      {% set zoffset = (calz + 3 - refz) %}
       { action_respond_info("BTC_Nudge: Calculated offsets for this tool:") }
-      { action_respond_info("BTC_Nudge: Z: %.2f" % (calz + 3 - refz)) }
-      { action_respond_info("BTC_Nudge: X: %.2f" % (calx - refx)) }
-      { action_respond_info("BTC_Nudge: Y: %.2f" % (caly - refy)) }
+      { action_respond_info("BTC_Nudge: Z: %.2f" % zoffset) }
+      { action_respond_info("BTC_Nudge: X: %.2f" % xoffset) }
+      { action_respond_info("BTC_Nudge: Y: %.2f" % yoffset) }
+      {% if printer["gcode_macro _btc_Variables"].use_save_variables and tool != -1 %}
+        _set_toolhead_offset_variables TOOL={tool} XOFFSET={xoffset|float} YOFFSET={yoffset|float} ZOFFSET={zoffset|float}
+        { action_respond_info("BTC_Nudge: Values are set on the tool for this session. Use LINEUX_SAVE_CONFIG to make them permanent.") }
+      {% endif %}
       { action_respond_info("BTC_Nudge: --- End Tool Offset Calibration ---") }
     {% endif %}
   {% endif %}
+
+[gcode_macro _set_toolhead_offset_variables]
+gcode:
+  {% set tool = params.TOOL|int %}
+  {% set xoffset = params.XOFFSET|float %}
+  {% set yoffset = params.YOFFSET|float %}
+  {% set zoffset = params.ZOFFSET|float %}
+
+  SET_GCODE_VARIABLE MACRO=_Variables_t{tool} VARIABLE=xoffset VALUE={xoffset}
+  SET_GCODE_VARIABLE MACRO=_Variables_t{tool} VARIABLE=yoffset VALUE={yoffset}
+  SET_GCODE_VARIABLE MACRO=_Variables_t{tool} VARIABLE=zoffset VALUE={zoffset}

--- a/Klipper/btc_save_variables.cfg
+++ b/Klipper/btc_save_variables.cfg
@@ -1,0 +1,54 @@
+[gcode_macro _load_toolhead_variable]
+gcode:
+  {% set tool = params.TOOL|default(0)|int %}
+  {% set name = params.VARIABLE %}
+
+  {% set svv = printer.save_variables.variables %}
+
+  {% set full_name = "lineux_t" ~ tool|int ~ "_" ~ name %}
+
+  {% if full_name in svv %}
+    SET_GCODE_VARIABLE MACRO=_Variables_t{tool} VARIABLE={name} VALUE={svv[full_name]}
+    { action_respond_info("BTC: Loaded dynamic value for T" ~ tool ~ " " ~ name ~ ": " ~ svv[full_name]) }
+  {% endif %}
+
+[gcode_macro _save_toolhead_variable]
+gcode:
+  {% set tool = params.TOOL|default(0)|int %}
+  {% set name = params.VARIABLE %}
+
+  {% set full_name = "lineux_t" ~ tool|int ~ "_" ~ name %}
+
+  {% if name in printer["gcode_macro _Variables_t" ~ tool|int] %}
+    SAVE_VARIABLE VARIABLE={full_name} VALUE={printer["gcode_macro _Variables_t" ~ tool|int][name]}
+    { action_respond_info("BTC: Saved dynamic value for T" ~ tool ~ ": " ~ name) }
+  {% else %}
+    { action_raise_error("BTC: Unknown variable for T" ~ tool ~ ": " ~ name) }
+  {% endif %}
+
+[gcode_macro Lineux_Load_Config]
+gcode:
+  {% set svv = printer.save_variables.variables %}
+  {% set TARGET_TEMP = svv.temperature_target %}
+
+  {% set numoftool = printer["gcode_macro _btc_Variables"].numoftool %}
+  {% for toolnumber in numoftool %}
+    _load_toolhead_variable TOOL={toolnumber|int} VARIABLE=xoffset
+    _load_toolhead_variable TOOL={toolnumber|int} VARIABLE=yoffset
+    _load_toolhead_variable TOOL={toolnumber|int} VARIABLE=zoffset
+
+    _load_toolhead_variable TOOL={toolnumber|int} VARIABLE=pickuplocation_x
+    _load_toolhead_variable TOOL={toolnumber|int} VARIABLE=dropofflocation_x
+  {% endfor %}
+
+[gcode_macro Lineux_Save_Config]
+gcode:
+  {% set numoftool = printer["gcode_macro _btc_Variables"].numoftool %}
+  {% for toolnumber in numoftool %}
+    _save_toolhead_variable TOOL={toolnumber|int} VARIABLE=xoffset
+    _save_toolhead_variable TOOL={toolnumber|int} VARIABLE=yoffset
+    _save_toolhead_variable TOOL={toolnumber|int} VARIABLE=zoffset
+
+    _save_toolhead_variable TOOL={toolnumber|int} VARIABLE=pickuplocation_x
+    _save_toolhead_variable TOOL={toolnumber|int} VARIABLE=dropofflocation_x
+  {% endfor %}

--- a/Klipper/btc_save_variables.cfg
+++ b/Klipper/btc_save_variables.cfg
@@ -37,8 +37,8 @@ gcode:
     _load_toolhead_variable TOOL={toolnumber|int} VARIABLE=yoffset
     _load_toolhead_variable TOOL={toolnumber|int} VARIABLE=zoffset
 
-    _load_toolhead_variable TOOL={toolnumber|int} VARIABLE=pickuplocation_x
-    _load_toolhead_variable TOOL={toolnumber|int} VARIABLE=dropofflocation_x
+    #_load_toolhead_variable TOOL={toolnumber|int} VARIABLE=pickuplocation_x
+    #_load_toolhead_variable TOOL={toolnumber|int} VARIABLE=dropofflocation_x
   {% endfor %}
 
 [gcode_macro Lineux_Save_Config]
@@ -49,6 +49,6 @@ gcode:
     _save_toolhead_variable TOOL={toolnumber|int} VARIABLE=yoffset
     _save_toolhead_variable TOOL={toolnumber|int} VARIABLE=zoffset
 
-    _save_toolhead_variable TOOL={toolnumber|int} VARIABLE=pickuplocation_x
-    _save_toolhead_variable TOOL={toolnumber|int} VARIABLE=dropofflocation_x
+    #_save_toolhead_variable TOOL={toolnumber|int} VARIABLE=pickuplocation_x
+    #_save_toolhead_variable TOOL={toolnumber|int} VARIABLE=dropofflocation_x
   {% endfor %}

--- a/Klipper/btc_variables.cfg
+++ b/Klipper/btc_variables.cfg
@@ -8,6 +8,7 @@ variable_btc_z_hop:                       0      # set this to 0 to disable z ho
 variable_btc_temp_allow:                  1.0    # Temperature allowance. This is range of set temperature. Use higher value if your pid is bad
 variable_btc_inc_leds:                    True   # Using neopixel
 variable_btc_enable_spoolman_integration: False  # Enable updating Spoolman upon toolchanges
+variable_use_save_variables:              False  # Enable dynamically saving toolhead variables
 
 variable_tool_approachlocation_y:      220    # Y absolute approach position
 variable_tool_approachlocation_z:      0      # NOTE: Currently only used if using sling + Dockslide. Z absolute approach position


### PR DESCRIPTION
This adds support for using `[save_variables]` functionality for dynamically setting & saving toolhead variables.
For now this supports the x/y/z offset variables and adds functionality to the btc_nudge code to utilize this.

When activated and you run `NUDGE_FIND_TOOL_OFFSETS`, the offsets of the tools will be temporarily set to 0 and will be temporarily set to the new calculated values after the nudge run finishes.
This then enables you to run `LINEUX_SAVE_CONFIG` to save these values.

Thus this enables "automatic" nudge runs without having to modify the configuration files manually afterwards.